### PR TITLE
Make use of `fs.FS` to allow for reading source files from different filesystems, configured via `Options.Filesystem`

### DIFF
--- a/interp/interp.go
+++ b/interp/interp.go
@@ -289,8 +289,8 @@ func New(options Options) *Interpreter {
 		i.opt.filesystem = options.Filesystem
 	} else {
 		// default to real filesystem
-		cwd, _ := os.Getwd() // FIXME: check error
-		i.opt.filesystem = os.DirFS(cwd)
+		//cwd, _ := os.Getwd() // FIXME: check error
+		i.opt.filesystem = os.DirFS("/")
 	}
 
 	i.opt.context.GOPATH = options.GoPath
@@ -417,7 +417,7 @@ func (interp *Interpreter) Eval(src string) (res reflect.Value, err error) {
 // by the interpreter, and a non nil error in case of failure.
 // The main function of the main package is executed if present.
 func (interp *Interpreter) EvalPath(path string) (res reflect.Value, err error) {
-	if !isFile(path) {
+	if !isFile(interp.opt.filesystem, path) {
 		_, err := interp.importSrc(mainID, path, NoTest)
 		return res, err
 	}
@@ -495,8 +495,8 @@ func (interp *Interpreter) Symbols(importPath string) Exports {
 	return m
 }
 
-func isFile(path string) bool {
-	fi, err := os.Stat(path)
+func isFile(filesystem fs.FS, path string) bool {
+	fi, err := fs.Stat(filesystem, path)
 	return err == nil && fi.Mode().IsRegular()
 }
 

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -289,7 +289,6 @@ func New(options Options) *Interpreter {
 		i.opt.filesystem = options.Filesystem
 	} else {
 		// default to real filesystem
-		//cwd, _ := os.Getwd() // FIXME: check error
 		i.opt.filesystem = os.DirFS("/")
 	}
 
@@ -422,7 +421,6 @@ func (interp *Interpreter) EvalPath(path string) (res reflect.Value, err error) 
 		return res, err
 	}
 
-	// b, err := ioutil.ReadFile(path)
 	b, err := fs.ReadFile(interp.filesystem, path)
 	if err != nil {
 		return res, err

--- a/interp/src.go
+++ b/interp/src.go
@@ -2,7 +2,7 @@ package interp
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -48,7 +48,7 @@ func (interp *Interpreter) importSrc(rPath, importPath string, skipTest bool) (s
 	}
 	interp.rdir[importPath] = true
 
-	files, err := ioutil.ReadDir(dir)
+	files, err := fs.ReadDir(interp.opt.filesystem, dir)
 	if err != nil {
 		return "", err
 	}
@@ -69,7 +69,7 @@ func (interp *Interpreter) importSrc(rPath, importPath string, skipTest bool) (s
 
 		name = filepath.Join(dir, name)
 		var buf []byte
-		if buf, err = ioutil.ReadFile(name); err != nil {
+		if buf, err = fs.ReadFile(interp.opt.filesystem, name); err != nil {
 			return "", err
 		}
 
@@ -185,13 +185,13 @@ func (interp *Interpreter) pkgDir(goPath string, root, importPath string) (strin
 	rPath := filepath.Join(root, "vendor")
 	dir := filepath.Join(goPath, "src", rPath, importPath)
 
-	if _, err := os.Stat(dir); err == nil {
+	if _, err := fs.Stat(interp.opt.filesystem, dir); err == nil {
 		return dir, rPath, nil // found!
 	}
 
 	dir = filepath.Join(goPath, "src", effectivePkg(root, importPath))
 
-	if _, err := os.Stat(dir); err == nil {
+	if _, err := fs.Stat(interp.opt.filesystem, dir); err == nil {
 		return dir, root, nil // found!
 	}
 
@@ -203,7 +203,7 @@ func (interp *Interpreter) pkgDir(goPath string, root, importPath string) (strin
 	}
 
 	rootPath := filepath.Join(goPath, "src", root)
-	prevRoot, err := previousRoot(rootPath, root)
+	prevRoot, err := previousRoot(interp.opt.filesystem, rootPath, root)
 	if err != nil {
 		return "", "", err
 	}
@@ -214,7 +214,7 @@ func (interp *Interpreter) pkgDir(goPath string, root, importPath string) (strin
 const vendor = "vendor"
 
 // Find the previous source root (vendor > vendor > ... > GOPATH).
-func previousRoot(rootPath, root string) (string, error) {
+func previousRoot(filesystem fs.FS, rootPath, root string) (string, error) {
 	rootPath = filepath.Clean(rootPath)
 	parent, final := filepath.Split(rootPath)
 	parent = filepath.Clean(parent)
@@ -227,7 +227,7 @@ func previousRoot(rootPath, root string) (string, error) {
 		// look for the closest vendor in one of our direct ancestors, as it takes priority.
 		var vendored string
 		for {
-			fi, err := os.Lstat(filepath.Join(parent, vendor))
+			fi, err := fs.Stat(filesystem, filepath.Join(parent, vendor))
 			if err == nil && fi.IsDir() {
 				vendored = strings.TrimPrefix(strings.TrimPrefix(parent, prefix), string(filepath.Separator))
 				break

--- a/interp/src.go
+++ b/interp/src.go
@@ -174,7 +174,7 @@ func (interp *Interpreter) rootFromSourceLocation() (string, error) {
 	pkgDir := filepath.Join(wd, filepath.Dir(sourceFile))
 	root := strings.TrimPrefix(pkgDir, filepath.Join(interp.context.GOPATH, "src")+"/")
 	if root == wd {
-		return "", fmt.Errorf("package location %s not in GOPATH (root=%s wd=%s)", pkgDir)
+		return "", fmt.Errorf("package location %s not in GOPATH", pkgDir)
 	}
 	return root, nil
 }

--- a/interp/src.go
+++ b/interp/src.go
@@ -174,7 +174,7 @@ func (interp *Interpreter) rootFromSourceLocation() (string, error) {
 	pkgDir := filepath.Join(wd, filepath.Dir(sourceFile))
 	root := strings.TrimPrefix(pkgDir, filepath.Join(interp.context.GOPATH, "src")+"/")
 	if root == wd {
-		return "", fmt.Errorf("package location %s not in GOPATH (root=%s wd=%s)", pkgDir, root, wd)
+		return "", fmt.Errorf("package location %s not in GOPATH (root=%s wd=%s)", pkgDir)
 	}
 	return root, nil
 }

--- a/interp/src.go
+++ b/interp/src.go
@@ -49,7 +49,7 @@ func (interp *Interpreter) importSrc(rPath, importPath string, skipTest bool) (s
 	interp.rdir[importPath] = true
 
 	// files, err := ioutil.ReadDir(dir)
-	files, err := fs.ReadDir(interp.filesystem, dir)
+	files, err := fs.ReadDir(interp.opt.filesystem, dir)
 	if err != nil {
 		return "", err
 	}
@@ -71,7 +71,7 @@ func (interp *Interpreter) importSrc(rPath, importPath string, skipTest bool) (s
 		name = filepath.Join(dir, name)
 		var buf []byte
 		// if buf, err = ioutil.ReadFile(name); err != nil {
-		if buf, err = fs.ReadFile(interp.filesystem, name); err != nil {
+		if buf, err = fs.ReadFile(interp.opt.filesystem, name); err != nil {
 			return "", err
 		}
 

--- a/interp/src.go
+++ b/interp/src.go
@@ -2,7 +2,7 @@ package interp
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -48,7 +48,8 @@ func (interp *Interpreter) importSrc(rPath, importPath string, skipTest bool) (s
 	}
 	interp.rdir[importPath] = true
 
-	files, err := ioutil.ReadDir(dir)
+	// files, err := ioutil.ReadDir(dir)
+	files, err := fs.ReadDir(interp.filesystem, dir)
 	if err != nil {
 		return "", err
 	}
@@ -69,7 +70,8 @@ func (interp *Interpreter) importSrc(rPath, importPath string, skipTest bool) (s
 
 		name = filepath.Join(dir, name)
 		var buf []byte
-		if buf, err = ioutil.ReadFile(name); err != nil {
+		// if buf, err = ioutil.ReadFile(name); err != nil {
+		if buf, err = fs.ReadFile(interp.filesystem, name); err != nil {
 			return "", err
 		}
 

--- a/interp/src.go
+++ b/interp/src.go
@@ -48,7 +48,6 @@ func (interp *Interpreter) importSrc(rPath, importPath string, skipTest bool) (s
 	}
 	interp.rdir[importPath] = true
 
-	// files, err := ioutil.ReadDir(dir)
 	files, err := fs.ReadDir(interp.opt.filesystem, dir)
 	if err != nil {
 		return "", err
@@ -70,7 +69,6 @@ func (interp *Interpreter) importSrc(rPath, importPath string, skipTest bool) (s
 
 		name = filepath.Join(dir, name)
 		var buf []byte
-		// if buf, err = ioutil.ReadFile(name); err != nil {
 		if buf, err = fs.ReadFile(interp.opt.filesystem, name); err != nil {
 			return "", err
 		}


### PR DESCRIPTION
* Defaults to `os.DirFS()` so that local filesystems are used by default and regular users should see no change in behaviour.
* `Options` has a new field `Filesystem fs.FS` so users can supply their own filesystem (I use one for http served zip files when targeting wasm. Tests can make use of `fstest.Map`)

TODO:
* [ ] Fix any broken tests (?)
  * There seem to be broken tests already (at least when I run master locally), how can I tell if I broke something new?
* [ ] New test(s) to cover new functionality
  * Use `fstest.Map` as the testing filesystem - https://pkg.go.dev/testing/fstest#MapFS